### PR TITLE
Add shebang line so pyp.py alone can be executed as "pyp" without ins…

### DIFF
--- a/pyp.py
+++ b/pyp.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import ast
 import inspect


### PR DESCRIPTION
…tallation

`pyp.py` rather usefully works alone and doesn't need installing. However, if it's just named `pyp` and run on a Linux system, it will be executed as a shell script because it doesn't have a shebang line. This PR adds that shebang so that `pyp.py` alone will work; it shouldn't make any difference to systems that don't detect the interpreter for a file, and will make things work on systems that do.