### PR TITLE
Bugfix: When a variable is defined by a for loop, count that as a definition

### DIFF
--- a/pyp.py
+++ b/pyp.py
@@ -50,7 +50,7 @@ def find_names(tree: ast.AST) -> Tuple[Set[str], Set[str]]:
         def generic_visit(self, node: ast.AST) -> None:
             # Adapted from ast.NodeVisitor.generic_visit, but re-orders traversal a little
             def order(f_v: Tuple[str, Any]) -> int:
-                return {"generators": -1, "target": 1, "targets": 1, "body": 2}.get(f_v[0], 0)
+                return {"generators": -1, "target": 1, "targets": 1, "body": 2, "ifs": 2}.get(f_v[0], 0)
 
             for _field, value in sorted(ast.iter_fields(node), key=order):
                 if isinstance(value, list):

--- a/pyp.py
+++ b/pyp.py
@@ -3,7 +3,7 @@ import argparse
 import ast
 import inspect
 import sys
-from typing import Any, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 __all__ = ["pypprint"]
 
@@ -50,7 +50,14 @@ def find_names(tree: ast.AST) -> Tuple[Set[str], Set[str]]:
         def generic_visit(self, node: ast.AST) -> None:
             # Adapted from ast.NodeVisitor.generic_visit, but re-orders traversal a little
             def order(f_v: Tuple[str, Any]) -> int:
-                return {"generators": -1, "target": 1, "targets": 1, "body": 2, "ifs": 2}.get(f_v[0], 0)
+                _order: Dict[str, int] = {
+                    "generators": -1,
+                    "target": 1,
+                    "targets": 1,
+                    "body": 2,
+                    "ifs": 2,
+                }
+                return _order.get(f_v[0], 0)
 
             for _field, value in sorted(ast.iter_fields(node), key=order):
                 if isinstance(value, list):

--- a/pyp.py
+++ b/pyp.py
@@ -50,7 +50,7 @@ def find_names(tree: ast.AST) -> Tuple[Set[str], Set[str]]:
         def generic_visit(self, node: ast.AST) -> None:
             # Adapted from ast.NodeVisitor.generic_visit, but re-orders traversal a little
             def order(f_v: Tuple[str, Any]) -> int:
-                return {"generators": -1, "target": 1, "targets": 1}.get(f_v[0], 0)
+                return {"generators": -1, "target": 1, "targets": 1, "body": 2}.get(f_v[0], 0)
 
             for _field, value in sorted(ast.iter_fields(node), key=order):
                 if isinstance(value, list):

--- a/tests/test_find_names.py
+++ b/tests/test_find_names.py
@@ -34,6 +34,7 @@ def test_comprehensions():
     assert ({"x"}, {"x"}) == find_names(ast.parse("(x for x in x)"))
     assert ({"x", "xx"}, {"xxx"}) == find_names(ast.parse("(x for xx in xxx for x in xx)"))
     assert ({"x", "xx"}, {"xx", "xxx"}) == find_names(ast.parse("(x for x in xx for xx in xxx)"))
+    assert ({"x"}, {"xx"}) == find_names(ast.parse("(x for x in xx if x == 'foo')"))
 
 
 def test_args():

--- a/tests/test_find_names.py
+++ b/tests/test_find_names.py
@@ -16,6 +16,11 @@ def test_builtins():
     assert ({"print"}, set()) == find_names(ast.parse("print = 5; print(5)"))
 
 
+def test_loops():
+    assert ({"x"}, {"y", "print"}) == find_names(ast.parse("for x in y: print(x)"))
+    assert (set(), {"x"}) == find_names(ast.parse("while x: pass"))
+
+
 def test_weird_assignments():
     assert ({"x"}, {"x"}) == find_names(ast.parse("x += 1"))
     assert ({"x"}, {"x"}) == find_names(ast.parse("for x in x: pass"))


### PR DESCRIPTION
## Bug

I ran this command:

```
cat pollution.csv | python3 pyp.py 'for row in lines: print(row)'
```

I got the following error:

```
Traceback (most recent call last):
  File "pyp.py", line 387, in <module>
    main()
  File "pyp.py", line 383, in main
    run_pyp(parse_options(sys.argv[1:]))
  File "pyp.py", line 332, in run_pyp
    exec(compile(tree, filename="<ast>", mode="exec"), {})
  File "<ast>", line 1, in <module>
ModuleNotFoundError: No module named 'row'
```

Using `--explain` gives this:

```
import row  # Bug here
import sys
lines = [x.rstrip('\n') for x in sys.stdin]
for row in lines:
    print(row)
```

## Expected behavior

pyp prints each line in a loop, as if I'd written `pyp 'x'`

## Fix

This function controls what order generic AST nodes are visited:

```
def order(f_v: Tuple[str, Any]) -> int:
```

Change the function so that the body of a loop is visited after the variables created by a for loop are defined.

I wrote a test for this issue as well.

PS: This is a great project. I come from an Awk background, and this is a really nice tool.