### PR TITLE
CI: Enable `jq` test

### DIFF
--- a/tests/test_pyp.py
+++ b/tests/test_pyp.py
@@ -49,7 +49,7 @@ def test_examples():
         input="echo echo",
     )
     compare_command(
-        example_cmd='jq .[1]["lol"]',
+        example_cmd="""jq -r '.[1]["lol"]'""",
         pyp_cmd="""pyp 'json.load(stdin)[1]["lol"]'""",
         input='[0, {"lol": "hmm"}, 0]',
     )

--- a/tests/test_pyp.py
+++ b/tests/test_pyp.py
@@ -52,7 +52,6 @@ def test_examples():
         example_cmd='jq .[1]["lol"]',
         pyp_cmd="""pyp 'json.load(stdin)[1]["lol"]'""",
         input='[0, {"lol": "hmm"}, 0]',
-        allow_example_fail=True,  # CI doesn't have jq and I don't care enough to change that
     )
     compare_command(
         example_cmd="grep -E '(py|md)'",


### PR DESCRIPTION
`jq` is already installed on Travis, so no need to install it.

I did have an issue with the test, both locally and in CI, so I fixed it. See commit 2 for details.