### PR TITLE
Count bytes in `wc -c` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Use the magic variable `lines` for a list of rstripped lines or `stdin` for `sys
 
 ```sh
 # pyp like wc -c
-cat /usr/share/dict/words | pyp 'len(stdin.read())'
+cat /usr/share/dict/words | pyp 'len(stdin.read().encode())'
 
 # pyp like awk
 seq 1 5 | pyp 'sum(map(int, lines))'


### PR DESCRIPTION
```shell
$ echo 🐍 | wc -c
       5

$ echo 🐍 | pyp 'len(stdin.read())'

2

$ echo 🐍 | pyp 'len(stdin.read().encode())'

5
```