### PR TITLE
Use actual pyp interpreter in shebang by default

### DIFF
--- a/pyp.py
+++ b/pyp.py
@@ -253,7 +253,7 @@ class PypConfig:
         # Modules from which automatic imports work without qualification, ordered by AST encounter
         self.wildcard_imports: List[str] = []
 
-        self.shebang: str = "#!/usr/bin/env python3"
+        self.shebang: str = f"#! {sys.interpreter}"
         if config_contents.startswith("#!"):
             self.shebang = "\n".join(
                 itertools.takewhile(lambda l: l.startswith("#"), config_contents.splitlines())


### PR DESCRIPTION
Current version:
```shell
~
$ pyp "'pyp is running on ' + sys.executable" --explain > explained.py

~
$ perl explained.py
Traceback (most recent call last):
  File "/Users/bobronium/explained.py", line 3, in <module>
    from pyp import pypprint
ModuleNotFoundError: No module named 'pyp'

~
$ cat explained.py
#!/usr/bin/env python3
import sys
from pyp import pypprint
assert sys.stdin.isatty() or not sys.stdin.read(), "The command doesn't process input, but input is present"
output = 'pyp is running on ' + sys.executable
if output is not None:
    pypprint(output)
```

With these changes:
```shell
~
$ pyp "'pyp is running on ' + sys.executable" --explain > explained.py

~
$ perl explained.py
pyp is running on /Users/bobronium/.local/pipx/venvs/pypyp/bin/python

~
$ cat explained.py
#!/Users/bobronium/.local/pipx/venvs/pypyp/bin/python
import sys
from pyp import pypprint
assert sys.stdin.isatty() or not sys.stdin.read(), "The command doesn't process input, but input is present"
output = 'pyp is running on ' + sys.executable
if output is not None:
    pypprint(output)
```
