### PR TITLE
Allow user to override pypprint

### DIFF
--- a/pyp.py
+++ b/pyp.py
@@ -526,10 +526,15 @@ class PypTransform:
         # get to `import sys`, we'll need to examine our wildcard imports, which in the presence
         # of config, could be slow.
         if "pypprint" in self.undefined:
-            pypprint_def = (
-                inspect.getsource(pypprint) if self.define_pypprint else "from pyp import pypprint"
-            )
-            self.before_tree.body = ast.parse(pypprint_def).body + self.before_tree.body
+            if "pypprint" in self.config.name_to_def:
+                pypprint_ast = [self.config.parts[self.config.name_to_def["pypprint"]]]
+            else:
+                pypprint_ast = ast.parse(
+                    inspect.getsource(pypprint)
+                    if self.define_pypprint
+                    else "from pyp import pypprint"
+                ).body
+            self.before_tree.body = pypprint_ast + self.before_tree.body
             self.undefined.remove("pypprint")
         if "sys" in self.undefined:
             self.before_tree.body = ast.parse("import sys").body + self.before_tree.body


### PR DESCRIPTION
This PR allows user to define their own pypprint.

## Example

I can define a custom config at `$PYP_CONFIG_PATH` as follows:
```python
import numpy as np
import plotly.express as pe
import matplotlib.pyplot as plt


def pypprint(*args, **kwargs):  # type: ignore
    from typing import Iterable
    import sys

    if len(args) != 1:
        return print(*args, **kwargs)

    x = args[0]

    if "matplotlib" in sys.modules:
        import matplotlib.pyplot as plt

        if any(isinstance(_x, plt.Artist) for _x in x):
            return plt.show()

    if "plotly" in sys.modules:
        import plotly.graph_objects as go

        if isinstance(x, go.Figure):
            return x.show()

    if isinstance(x, dict):
        for k, v in x.items():
            return print(f"{k}:", v, **kwargs)
    elif isinstance(x, Iterable) and not isinstance(x, str):
        for i in x:
            print(i, **kwargs)
        return
    else:
        return print(x, **kwargs)

```

then, running 
```sh
pyp 'plt.plot([0,1,1.5])'
```
automatically open the plot for you:)

-----------------

*Note, the return statement simply allows me to short-circuit the flow; and the checking on sys.modules helps to avoid unnecessary import of modules if the modules is not already imported